### PR TITLE
Add interactive HTML interface for prompt generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,597 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Генератор на промпти</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1.5;
+        background-color: #f5f5f5;
+        color: #222;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        padding: 2rem 1rem 4rem;
+      }
+
+      main {
+        width: min(960px, 100%);
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 18px;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+        padding: 2rem;
+        backdrop-filter: blur(6px);
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 2rem;
+      }
+
+      header h1 {
+        font-size: clamp(2rem, 5vw, 2.8rem);
+        margin-bottom: 0.5rem;
+      }
+
+      header p {
+        color: #475569;
+        margin: 0;
+      }
+
+      form {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      fieldset {
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+      }
+
+      fieldset legend {
+        font-weight: 600;
+        padding: 0 0.5rem;
+      }
+
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.35rem;
+      }
+
+      input[type="text"],
+      select,
+      textarea,
+      input[type="number"] {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid #cbd5f5;
+        border-radius: 10px;
+        background: #fff;
+        font: inherit;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input[type="text"]:focus,
+      select:focus,
+      textarea:focus,
+      input[type="number"]:focus {
+        outline: none;
+        border-color: #6366f1;
+        box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+      }
+
+      textarea {
+        min-height: 120px;
+        resize: vertical;
+      }
+
+      .options-grid {
+        display: grid;
+        gap: 1rem;
+      }
+
+      @media (min-width: 720px) {
+        .options-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .checkbox-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .checkbox-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.6rem;
+        font-weight: 500;
+      }
+
+      .checkbox-item input {
+        margin-top: 0.25rem;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.9rem 1.8rem;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      button.primary {
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: white;
+        box-shadow: 0 14px 30px rgba(99, 102, 241, 0.35);
+      }
+
+      button.secondary {
+        background: #e2e8f0;
+        color: #1e293b;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+      }
+
+      button:active {
+        transform: translateY(0);
+      }
+
+      .output-card {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 1.5rem;
+        border-radius: 16px;
+        margin-top: 1.5rem;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+      }
+
+      .output-card h2 {
+        margin-top: 0;
+        font-size: 1.25rem;
+      }
+
+      .output-card textarea {
+        margin-top: 1rem;
+        background: rgba(15, 23, 42, 0.8);
+        color: inherit;
+        border-color: rgba(148, 163, 184, 0.35);
+      }
+
+      .helper-text {
+        color: #64748b;
+        font-size: 0.9rem;
+      }
+
+      .tag-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+      }
+
+      .tag-list button {
+        padding: 0.4rem 0.9rem;
+        border-radius: 999px;
+        background: #f1f5f9;
+        color: #1f2937;
+        font-size: 0.85rem;
+        font-weight: 500;
+        box-shadow: none;
+      }
+
+      footer {
+        text-align: center;
+        margin-top: 2rem;
+        color: #64748b;
+        font-size: 0.85rem;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Генератор на промпти</h1>
+        <p>
+          Създайте прецизни инструкции за модели с изкуствен интелект, като
+          комбинирате контекст, цели и ограничения.
+        </p>
+      </header>
+
+      <form id="generatorForm" autocomplete="off">
+        <fieldset>
+          <legend>Основна информация</legend>
+          <div class="options-grid">
+            <label>
+              Тема или задача
+              <input
+                type="text"
+                id="topic"
+                name="topic"
+                placeholder="Опишете основната задача, напр. \"обясни квантовата суперпозиция\""
+              />
+            </label>
+            <label>
+              Целева аудитория
+              <input
+                type="text"
+                id="audience"
+                name="audience"
+                placeholder="Ученици, маркетинг специалисти, програмисти..."
+              />
+            </label>
+            <label>
+              Изходен формат
+              <select id="format" name="format">
+                <option value="обяснение">Подробно обяснение</option>
+                <option value="списък" selected>Структуриран списък</option>
+                <option value="кодов пример">Кодов пример</option>
+                <option value="статия">Кратка статия</option>
+                <option value="сценарий">Сценарий/Диалог</option>
+              </select>
+            </label>
+            <label>
+              Желана дължина
+              <input
+                type="text"
+                id="length"
+                name="length"
+                placeholder="Напр. 300 думи, 5 стъпки, 3 идеи"
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Тон и стил</legend>
+          <div class="options-grid">
+            <label>
+              Тон
+              <select id="tone" name="tone">
+                <option value="неутрален">Неутрален</option>
+                <option value="приятелски">Приятелски</option>
+                <option value="професионален">Професионален</option>
+                <option value="вдъхновяващ">Вдъхновяващ</option>
+                <option value="технически">Технически</option>
+              </select>
+            </label>
+            <label>
+              Езикови насоки
+              <input
+                type="text"
+                id="language"
+                name="language"
+                placeholder="Използвай прости думи, включи примери, цитирай източници..."
+              />
+            </label>
+            <label>
+              Контекст
+              <textarea
+                id="context"
+                name="context"
+                placeholder="Въведете ключова информация, която моделът трябва да използва"
+              ></textarea>
+            </label>
+            <label>
+              Ограничения
+              <textarea
+                id="constraints"
+                name="constraints"
+                placeholder="Избягвай ..., включи ..., следвай определен формат..."
+              ></textarea>
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Фокус и допълнителни акценти</legend>
+          <div class="checkbox-group">
+            <label class="checkbox-item">
+              <input type="checkbox" id="needExamples" name="needExamples" />
+              <span>Добави конкретни примери или аналогии.</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="needSteps" name="needSteps" />
+              <span>Структурирай отговора като последователни стъпки.</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="needSummary" name="needSummary" />
+              <span>Завърши с кратко резюме на основните идеи.</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="needFollowUp" name="needFollowUp" />
+              <span>Предложи допълнителни въпроси или следващи действия.</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Бързи шаблони</legend>
+          <p class="helper-text">
+            Използвайте готов шаблон като начална точка. След избиране, можете да
+            редактирате полетата според нуждите си.
+          </p>
+          <div class="tag-list" role="list">
+            <button type="button" data-template="marketing">
+              Маркетингова кампания
+            </button>
+            <button type="button" data-template="education">
+              Образователно обяснение
+            </button>
+            <button type="button" data-template="code">
+              Кодов асистент
+            </button>
+            <button type="button" data-template="brainstorm">
+              Мозъчна атака
+            </button>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Допълнителни инструкции</legend>
+          <label class="visually-hidden" for="customInstructions"
+            >Свободен текст</label
+          >
+          <textarea
+            id="customInstructions"
+            name="customInstructions"
+            placeholder="Добавете специфични изисквания, критерии за оценка или контекст"
+          ></textarea>
+        </fieldset>
+
+        <div class="actions">
+          <button type="button" class="primary" id="generateButton">
+            Генерирай промпт
+          </button>
+          <button type="button" class="secondary" id="copyButton">
+            Копирай в клипборда
+          </button>
+          <span id="copyStatus" aria-live="polite"></span>
+        </div>
+      </form>
+
+      <section class="output-card" aria-live="polite">
+        <h2>Готов промпт</h2>
+        <textarea id="promptOutput" readonly rows="10"></textarea>
+      </section>
+
+      <footer>Създадено за експерименти и усъвършенстване на AI промпти.</footer>
+    </main>
+
+    <script>
+      const form = document.getElementById("generatorForm");
+      const output = document.getElementById("promptOutput");
+      const copyButton = document.getElementById("copyButton");
+      const copyStatus = document.getElementById("copyStatus");
+      const generateButton = document.getElementById("generateButton");
+
+      const templateButtons = Array.from(
+        document.querySelectorAll("[data-template]")
+      );
+
+      const templates = {
+        marketing: {
+          topic: "Създай концепция за кампания на нов продукт",
+          audience: "Млади професионалисти на 25-35 години",
+          format: "статия",
+          length: "400 думи",
+          tone: "вдъхновяващ",
+          language: "Използвай динамичен и позитивен език",
+          context:
+            "Продуктът е мобилно приложение за управление на личните финанси",
+          constraints:
+            "Представи три уникални ценови предложения и призив към действие",
+          needExamples: true,
+          needSteps: false,
+          needSummary: true,
+          needFollowUp: true,
+        },
+        education: {
+          topic: "Обясни понятието машинно обучение",
+          audience: "Ученици в гимназия",
+          format: "обяснение",
+          length: "5 параграфа",
+          tone: "приятелски",
+          language: "Използвай разбираеми примери и аналогии",
+          context:
+            "Учениците имат базови познания по програмиране, но не и по статистика",
+          constraints: "Не използвай сложни математически формули",
+          needExamples: true,
+          needSteps: true,
+          needSummary: true,
+          needFollowUp: false,
+        },
+        code: {
+          topic: "Помогни за оптимизация на функция в JavaScript",
+          audience: "Frontend разработчик",
+          format: "кодов пример",
+          length: "Сравнение на оригинален и подобрен код",
+          tone: "технически",
+          language: "Добави обяснения за всяка оптимизация",
+          context:
+            "Функцията филтрира и сортира големи масиви с данни за таблица",
+          constraints:
+            "Предложи решения с по-добра сложност и обясни потенциалните компромиси",
+          needExamples: true,
+          needSteps: true,
+          needSummary: false,
+          needFollowUp: true,
+        },
+        brainstorm: {
+          topic: "Генерирай идеи за устойчиви фирмени подаръци",
+          audience: "HR екип",
+          format: "списък",
+          length: "10 идеи",
+          tone: "професионален",
+          language: "Подчертай екологичните ползи",
+          context: "Бюджет до 40 лв. на служител",
+          constraints: "Идеите трябва да са локално произведени",
+          needExamples: false,
+          needSteps: false,
+          needSummary: false,
+          needFollowUp: true,
+        },
+      };
+
+      const controls = {
+        topic: document.getElementById("topic"),
+        audience: document.getElementById("audience"),
+        format: document.getElementById("format"),
+        length: document.getElementById("length"),
+        tone: document.getElementById("tone"),
+        language: document.getElementById("language"),
+        context: document.getElementById("context"),
+        constraints: document.getElementById("constraints"),
+        customInstructions: document.getElementById("customInstructions"),
+        needExamples: document.getElementById("needExamples"),
+        needSteps: document.getElementById("needSteps"),
+        needSummary: document.getElementById("needSummary"),
+        needFollowUp: document.getElementById("needFollowUp"),
+      };
+
+      function applyTemplate(templateKey) {
+        const template = templates[templateKey];
+        Object.entries(template).forEach(([key, value]) => {
+          const control = controls[key];
+          if (!control) return;
+          if (typeof value === "boolean") {
+            control.checked = value;
+          } else {
+            control.value = value;
+          }
+        });
+        updateOutput();
+      }
+
+      templateButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          applyTemplate(button.dataset.template);
+        });
+      });
+
+      function buildPrompt() {
+        const values = Object.fromEntries(
+          Object.entries(controls).map(([key, control]) => [
+            key,
+            control.type === "checkbox" ? control.checked : control.value.trim(),
+          ])
+        );
+
+        const sections = [];
+
+        if (values.topic) {
+          sections.push(
+            `Задача: Създай ${values.format || "отговор"} по темата "${values.topic}".`
+          );
+        }
+
+        if (values.audience) {
+          sections.push(`Целева аудитория: ${values.audience}.`);
+        }
+
+        const styleInstructions = [];
+        if (values.tone) styleInstructions.push(`Тон: ${values.tone}.`);
+        if (values.language)
+          styleInstructions.push(`Езикови насоки: ${values.language}.`);
+        if (values.length)
+          styleInstructions.push(`Желана дължина: ${values.length}.`);
+        if (styleInstructions.length) {
+          sections.push(styleInstructions.join(" "));
+        }
+
+        if (values.context) {
+          sections.push(`Контекст: ${values.context}.`);
+        }
+
+        if (values.constraints) {
+          sections.push(`Ограничения: ${values.constraints}.`);
+        }
+
+        const focusPoints = [];
+        if (values.needExamples)
+          focusPoints.push("Добави конкретни примери.");
+        if (values.needSteps)
+          focusPoints.push("Подреди информацията като последователни стъпки.");
+        if (values.needSummary)
+          focusPoints.push("Завърши с кратко резюме.");
+        if (values.needFollowUp)
+          focusPoints.push("Предложи последващи въпроси или действия.");
+        if (focusPoints.length) {
+          sections.push(`Акценти: ${focusPoints.join(" ")}`);
+        }
+
+        if (values.customInstructions) {
+          sections.push(`Допълнителни инструкции: ${values.customInstructions}.`);
+        }
+
+        return sections.join("\n\n");
+      }
+
+      function updateOutput() {
+        output.value = buildPrompt();
+      }
+
+      form.addEventListener("input", (event) => {
+        if (event.target === copyButton) return;
+        updateOutput();
+      });
+
+      generateButton.addEventListener("click", updateOutput);
+
+      copyButton.addEventListener("click", async () => {
+        if (!output.value) {
+          copyStatus.textContent = "Няма съдържание за копиране.";
+          return;
+        }
+
+        try {
+          await navigator.clipboard.writeText(output.value);
+          copyStatus.textContent = "Промптът е копиран!";
+          setTimeout(() => (copyStatus.textContent = ""), 3000);
+        } catch (error) {
+          copyStatus.textContent = "Копирането не бе успешно. Опитайте ръчно.";
+        }
+      });
+
+      // Попълни стойности по подразбиране при зареждане
+      updateOutput();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page for configuring and generating AI prompts
- include reusable templates, customizable fields, and clipboard copy helpers
- style the layout with responsive design for comfortable use

## Testing
- not run (static HTML)

------
https://chatgpt.com/codex/tasks/task_e_68cbb85112a48326a61b36eca0543de8